### PR TITLE
FIX: Injected Hulkcodes causing wrong items to be added from pdp

### DIFF
--- a/assets/custom.js
+++ b/assets/custom.js
@@ -317,7 +317,7 @@ function ajaxAddToCart(){
         window.location = product.url
       });
     } else {
-      $this.click( () => {
+      $this.on('click', () => {
         addItemToCart(product.variant_id, 1);    // paste your id product number
       })
     };

--- a/assets/theme.js
+++ b/assets/theme.js
@@ -2626,7 +2626,7 @@
       key: "_addToCart",
       value: function _addToCart(event) {
         var _this4 = this;
-const validateObjectData = validate_options(window.hulkapps.product_id);
+            const validateObjectData = validate_options(window.hulkapps.product_id);
             const validateObjectValue = async () => {
               const v = await validateObjectData;
               if (v == true) {

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -380,7 +380,12 @@
                         </style>
                       {%- endif -%}
   
-                      <button id="main-product_buy" type="submit" data-use-primary-button="{% if use_primary_button %}true{% else %}false{% endif %}" class="ProductForm__AddToCart Button {% if product.selected_or_first_available_variant.available and use_primary_button %}Button--primary{% else %}Button--secondary{% endif %} Button--full" {% if product.selected_or_first_available_variant.available %}data-action="add-to-cart"{% else %}disabled="disabled"{% endif %}>
+                      <button 
+                        id="main-product_buy" 
+                        type="submit" 
+                        data-use-primary-button="{% if use_primary_button %}true{% else %}false{% endif %}" 
+                        class="ProductForm__AddToCart Button {% if product.selected_or_first_available_variant.available and use_primary_button %}Button--primary{% else %}Button--secondary{% endif %} Button--full" {% if product.selected_or_first_available_variant.available %}data-action="add-to-cart"{% else %}disabled="disabled"{% endif %}
+                      >
                         {%- if product.selected_or_first_available_variant.available -%}
                           <span>{% if product.template_suffix == 'pre-order' %}{{ 'product.form.pre_order' | t }}{% else %}{{ 'product.form.add_to_cart' | t }}{% endif %}</span>
   

--- a/snippets/atc-button-ajax.liquid
+++ b/snippets/atc-button-ajax.liquid
@@ -25,7 +25,24 @@ Variables:
 {% endfor %}
 
 {% assign available_prod_grid_item = product.selected_or_first_available_variant.available %}
-<button data-prod-url="{{ product.url }}" data-prod-collections="{{ prod_collections }}" data-prod-type="{{ product.type }}" data-prod-vendor="{{ product.vendor }}" data-prod-tags="{{ prod_tags }}" data-prod-id="{{ product.id }}" type="submit" name="add" aria-label="Add to cart" class="ad_to_cart_coll ProductForm__AddToCart Button Button--secondary Button--full" id="ad_to_cart" aria-haspopup="dialog" data-add-to-cart="{{ product.variants.first.id }}" data-var_id="{{ product.variants.first.id }}" data-prod-available="{{ available_prod_grid_item }}">
+<a 
+  data-prod-url="{{ product.url }}" 
+  data-prod-collections="{{ prod_collections }}" 
+  data-prod-type="{{ product.type }}" 
+  data-prod-vendor="{{ product.vendor }}" 
+  data-prod-tags="{{ prod_tags }}" 
+  data-prod-id="{{ product.id }}" 
+  {% comment %} type="submit"  {% endcomment %}
+  name="add" 
+  aria-label="Add to cart" 
+  class="ad_to_cart_coll ProductForm__AddToCart Button Button--secondary Button--full" 
+  style="cursor:pointer;"
+  id="ad_to_cart" 
+  aria-haspopup="dialog" 
+  data-add-to-cart="{{ product.variants.first.id }}" 
+  data-var_id="{{ product.variants.first.id }}" 
+  data-prod-available="{{ available_prod_grid_item }}"
+>
   {%- if available_prod_grid_item -%}
     <span>{% if product.template_suffix == 'pre-order' %}{{ 'product.form.pre_order' | t }}{% else %}{{ 'product.form.add_to_cart' | t }}{% endif %}</span>
 
@@ -36,4 +53,4 @@ Variables:
   {%- else -%}
     {{- 'product.form.sold_out' | t -}}
   {%- endif -%}
-</button>
+</a>


### PR DESCRIPTION
- The featured products at the bottom of the pdp were getting a `atc` class added by the injected hulkcode (not the local asset). This was causing the main `atc` button on the pdp to act weird and sometimes add one of the items from the featured prods section. I changed the featured prods `<button>` to `<a>` and this made the hulkapps code not add the class that was causing this weird click event.